### PR TITLE
changing the example since visibility also removes from a11y tree

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,11 +220,11 @@ kbd {
   <pre class="nohighlight"><code class="block">&lt;<mark>button</mark> <mark>aria-hidden="true"</mark>&gt;press me&lt;/<mark>button</mark>&gt;</code>   </pre>
   <p class="note">If an interactive element <strong>cannot be seen or interacted with</strong>, then you can apply <code>aria-hidden</code>, for example:</p>
 <pre class="nohighlight">
- <code class="block"><mark>button {visibility:hidden}</mark>
+ <code class="block"><mark>button {opacity:0}</mark>
 
-&lt;<mark>button</mark> <mark>aria-hidden="true"</mark>&gt;press me&lt;/<mark>button</mark>&gt;</code></pre>
+&lt;<mark>button</mark> <mark>tabindex="-1" aria-hidden="true"</mark>&gt;press me&lt;/<mark>button</mark>&gt;</code></pre>
 
-  <p class="note">If an interactive element is hidden using <code>display:none</code>, it 
+  <p class="note">If an interactive element is hidden using <code>display:none</code> or <code>visibility:hidden</code>, it 
   will also be removed from the <a href="https://www.w3.org/TR/accname-aam-1.1/#dfn-accessibility-tree">accessibility tree</a>, which makes the
   addition of <code>aria-hidden="true"</code> unnecessary.</p>
  </section>


### PR DESCRIPTION
This because I received a mail showing how this could cause confusion and our goal is to reduce using aria when it's not necessary:
![screenshot of section 2.4, Fourth rule of ARIA. Afterwards comment from a colleague: while they mention display:none means aria-hidden isn't required they seem to imply that using visibility:hidden  + aria-hidden is OK](https://user-images.githubusercontent.com/136210/34774793-103bc738-f611-11e7-8757-2c7129fa4cfd.png)

An example (if needed) where a slight mishap again makes aria-hidden dangerous (mail thread): https://mail.gnome.org/archives/orca-list/2018-January/msg00065.html
